### PR TITLE
Add is_singular() check

### DIFF
--- a/admin-bar.php
+++ b/admin-bar.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function dpm_menu_bar() {
 
-	if ( current_user_can( 'manage_options' ) && ! is_archive() && ! is_admin() && ! is_search() && ! is_404() && ! is_home() ) {
+	if ( current_user_can( 'manage_options' ) && ! is_archive() && ! is_admin() && ! is_search() && ! is_404() && ! is_home() && is_singular() ) {
 		global $wp_admin_bar;
 		$query = isset( $_GET['show_meta'] ) ? true : false;
 		if ( $query === true ) {


### PR DESCRIPTION
This will ensure that the link only shows on front-end content, regardless of post type. Function reference can be found at : https://codex.wordpress.org/Function_Reference/is_singular